### PR TITLE
#32 Use "Subtract" instead of "Add in macros when calculating TGI. 

### DIFF
--- a/Maize/bin/plugins.config
+++ b/Maize/bin/plugins.config
@@ -6,7 +6,7 @@
 
 
 # Author: George El-Haddad
-# Version: 1.14
+# Version: 1.15
 # Date: 2015/11/05
 # Requires: ImageJ 1.49m
 

--- a/Maize/src/cimmyt/maize/MaizeScanner.java
+++ b/Maize/src/cimmyt/maize/MaizeScanner.java
@@ -18,7 +18,7 @@ import cimmyt.maize.ui.tools.UITool;
  */
 public class MaizeScanner implements PlugIn {
         
-        public static final String VERSION = "1.14";
+        public static final String VERSION = "1.15";
         private MaizeFrame frame = null;
         
         @Override

--- a/Maize/src/cimmyt/maize/ui/macros/canopy/ngrditgi/Wheat_RGB_VegetationIndexes_v1.ijm
+++ b/Maize/src/cimmyt/maize/ui/macros/canopy/ngrditgi/Wheat_RGB_VegetationIndexes_v1.ijm
@@ -56,7 +56,7 @@ function action(filename) {
         model aircraft for remote sensing of crop biomass and nitrogen status."
         Precision Agriculture 6.4 (2005): 359-378.
     */
-    imageCalculator("Add create 32-bit", "IMG_(red)","IMG_(blue)");
+    imageCalculator("Subtract create 32-bit", "IMG_(red)","IMG_(blue)");
     rename("ResultR-B");
     imageCalculator("Subtract create 32-bit", "IMG_(red)","IMG_(green)");
     rename("ResultR-G");

--- a/Maize/src/cimmyt/maize/ui/macros/leaf/maizefields/AnalyzeMaizeFieldPhotos_BatchComponents_HSBplusNGRDIandTGIv3Bish.ijm
+++ b/Maize/src/cimmyt/maize/ui/macros/leaf/maizefields/AnalyzeMaizeFieldPhotos_BatchComponents_HSBplusNGRDIandTGIv3Bish.ijm
@@ -350,7 +350,7 @@ function action(input, output, filename) {
 	NGRDI = getResult("Mean");
 	
 	//Use image math calculator plus functions to calculate the TGI
-	imageCalculator("Add create 32-bit", "IMG_(red)","IMG_(blue)");
+	imageCalculator("Subtract create 32-bit", "IMG_(red)","IMG_(blue)");
 	rename("ResultR-B");
 	imageCalculator("Subtract create 32-bit", "IMG_(red)","IMG_(green)");
 	rename("ResultR-G");

--- a/Maize/src/cimmyt/maize/ui/macros/leaf/maizefields/MaizeFieldsMacroPanel.java
+++ b/Maize/src/cimmyt/maize/ui/macros/leaf/maizefields/MaizeFieldsMacroPanel.java
@@ -23,6 +23,7 @@ import javax.swing.JTextField;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rtextarea.RTextScrollPane;
+import cimmyt.maize.MaizeScanner;
 import cimmyt.maize.ui.MaizeFrame;
 import cimmyt.maize.ui.macros.canopy.maize.MaizeMacroPanel;
 import cimmyt.maize.ui.tools.FileOpen;
@@ -493,7 +494,7 @@ public class MaizeFieldsMacroPanel extends JPanel {
         }
         
         private final void resultsFileButton_actionPerformed() {
-                saveResultsFile = FileSave.saveFile("Name Results File", (recentDir == null ? new File(System.getProperty("user.dir")) : new File(recentDir)), "Results File (*.csv)", "MaizePlotPhotos-Soil-GA-GGA-Chlorosis-Necrosis-HSB-CIELAB-NGRDI-TGI-PlotMLN-ResultsV3.csv");
+                saveResultsFile = FileSave.saveFile("Name Results File", (recentDir == null ? new File(System.getProperty("user.dir")) : new File(recentDir)), "Results File (*.csv)", "Maize_PlotImages_v"+MaizeScanner.VERSION+"_Results.csv");
                 if(saveResultsFile != null) {
                         recentDir = saveResultsFile.getParentFile().getAbsolutePath();
                         

--- a/Maize/src/cimmyt/maize/ui/macros/leaf/maizescans/AnalyzeMaizeScans_BatchComponents_HSBplusplusNGRDIandTGIv3Yoseph.ijm
+++ b/Maize/src/cimmyt/maize/ui/macros/leaf/maizescans/AnalyzeMaizeScans_BatchComponents_HSBplusplusNGRDIandTGIv3Yoseph.ijm
@@ -363,7 +363,7 @@ function action(input, output, filename) {
 	NGRDI = getResult("Mean");
 	
 	//Use image math calculator plus functions to calculate the TGI
-	imageCalculator("Add create 32-bit", "IMG_(red)","IMG_(blue)");
+	imageCalculator("Subtract create 32-bit", "IMG_(red)","IMG_(blue)");
 	rename("ResultR-B");
 	imageCalculator("Subtract create 32-bit", "IMG_(red)","IMG_(green)");
 	rename("ResultR-G");

--- a/Maize/src/cimmyt/maize/ui/macros/leaf/maizescans/MaizeScansMacroPanel.java
+++ b/Maize/src/cimmyt/maize/ui/macros/leaf/maizescans/MaizeScansMacroPanel.java
@@ -23,6 +23,7 @@ import javax.swing.JTextField;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rtextarea.RTextScrollPane;
+import cimmyt.maize.MaizeScanner;
 import cimmyt.maize.ui.MaizeFrame;
 import cimmyt.maize.ui.macros.canopy.maize.MaizeMacroPanel;
 import cimmyt.maize.ui.tools.FileOpen;
@@ -493,7 +494,7 @@ public class MaizeScansMacroPanel extends JPanel {
         }
         
         private final void resultsFileButton_actionPerformed() {
-                saveResultsFile = FileSave.saveFile("Name Results File", (recentDir == null ? new File(System.getProperty("user.dir")) : new File(recentDir)), "Results File (*.csv)", "MaizeLeafScans-GA-GGA-Chlorosis-Necrosis-HSB-CIELAB-NGRDI-TGI-LeafMLN-ResultsV3.csv");
+                saveResultsFile = FileSave.saveFile("Name Results File", (recentDir == null ? new File(System.getProperty("user.dir")) : new File(recentDir)), "Results File (*.csv)", "Maize_LeafScans_v"+MaizeScanner.VERSION+"_Results.csv");
                 if(saveResultsFile != null) {
                         recentDir = saveResultsFile.getParentFile().getAbsolutePath();
                         

--- a/Maize/src/plugins.config
+++ b/Maize/src/plugins.config
@@ -6,7 +6,7 @@
 
 
 # Author: George El-Haddad
-# Version: 1.14
+# Version: 1.15
 # Date: 2015/11/05
 # Requires: ImageJ 1.49m
 


### PR DESCRIPTION
Use "Subtract" instead of "Add in macros when calculating TGI. 
Shortened default results file name for maize leaf and field scan macros.